### PR TITLE
fix: remove sdk vanity prefix

### DIFF
--- a/vangen.json
+++ b/vangen.json
@@ -20,22 +20,6 @@
       }
     },
     {
-      "prefix": "flipt/sdk",
-      "type": "git",
-      "url": "https://github.com/flipt-io/flipt",
-      "subs": [
-        "sdk/go"
-      ],
-      "source": {
-        "home": "https://github.com/flipt-io/flipt/tree/main/sdk/go",
-        "dir": "https://github.com/flipt-io/flipt/tree/main/sdk/go{/dir}",
-        "file": "https://github.com/flipt-io/flipt/blob/main/sdk/go{/dir}/{file}#L{line}"
-      },
-      "website": {
-        "URL": "https://flipt.io"
-      }
-    },
-    {
       "prefix": "flipt-grpc",
       "type": "git",
       "url": "https://github.com/flipt-io/flipt-grpc-go",


### PR DESCRIPTION
Removing this for now. If we ever spin up a read-only mirror of the SDK we can point it there.