### PR TITLE
feat: add stew vanity path

### DIFF
--- a/vangen.json
+++ b/vangen.json
@@ -44,6 +44,11 @@
         "dir": "https://github.com/flipt-io/flipt-openfeature-provider-go/tree/main{/dir}",
         "file": "https://github.com/flipt-io/flipt-openfeature-provider-go/blob/main{/dir}/{file}#L{line}"
       }
+    },
+    {
+      "prefix": "stew",
+      "type": "git",
+      "url": "https://github.com/flipt-io/stew"
     }
   ]
 }


### PR DESCRIPTION
This is just a useful thing to be reachable via `go.flipt.io/stew`.
I am updating Flipt proper to use stew to provision Gitea.

https://github.com/flipt-io/stew